### PR TITLE
Moved cstring functions with other std includes

### DIFF
--- a/boot/linux-x86_64/setup.cc
+++ b/boot/linux-x86_64/setup.cc
@@ -23,8 +23,8 @@
 
 #include "libsupcxx/boot/bootinfo.hh"
 #include "libsupcxx/boot/linux-x86_64/syscall.h"
-#include "libsupcxx/io/string.hh"
 
+#include <cstring>
 #include <cstdint>
 
 // The length of the heap to allocate can be specified by an environment
@@ -40,9 +40,9 @@ BootInfo bootInfo;
 
 // Similar to standard getenv, but takes envp as argument
 extern "C" const char *_getenv(const char **envp, const char *name) {
-  size_t len = io::strlen(name);
+  size_t len = strlen(name);
   for (const char **env = envp; *env; ++env) {
-    if (io::strncmp(*env, name, len) == 0) {
+    if (strncmp(*env, name, len) == 0) {
       return *env + len + 1;
     }
   }
@@ -53,7 +53,7 @@ extern "C" const char *_getenv(const char **envp, const char *name) {
 extern "C" size_t _heapLen(const char **envp) {
   const char *env = _getenv(envp, ENV_HEAPLEN);
   if (env) {
-    return io::strtoul(env, nullptr, 0);
+    return strtoul(env, nullptr, 0);
   }
   return HEAPLEN_DEFAULT;
 }
@@ -63,8 +63,8 @@ extern "C" size_t _heapLen(const char **envp) {
 extern "C" char *_addCmdLine(size_t argc, const char **argv, char *heap) {
   char *end = heap;
   for (size_t i = 0; i < argc; ++i) {
-    size_t len = io::strlen(argv[i]);
-    io::strncpy(end, argv[i], len);
+    size_t len = strlen(argv[i]);
+    strncpy(end, argv[i], len);
     if (i == argc - 1) {
       end[len] = '\0';
     } else {
@@ -91,7 +91,7 @@ extern "C" void _systemSetup(size_t argc, const char **argv,
 
   // Check for failure. Unlike mmap, SYS_mmap can return a range of errno's
   if (mmapReturn >= -4095 && mmapReturn <= -1) {
-    _syscall(SYS_write, STDOUT_FILENO, MMAP_ERR_MSG, io::strlen(MMAP_ERR_MSG));
+    _syscall(SYS_write, STDOUT_FILENO, MMAP_ERR_MSG, strlen(MMAP_ERR_MSG));
     _syscall(SYS_exit, 1);
   }
 

--- a/boot/raspi3/setup.cc
+++ b/boot/raspi3/setup.cc
@@ -23,7 +23,7 @@
 
 #include "libsupcxx/boot/bootinfo.hh"
 
-#include "libsupcxx/io/string.hh"
+#include <cstring>
 
 // These variables do not exist, but their addresses are known to the linker.
 // See the linker script for details.
@@ -64,11 +64,11 @@ extern "C" void _systemSetup(BootInfo *info) {
   info->cmdline = (char*)0x12c;
 
   // See if we have some bootloader information passed on the commandline
-  const char *vcBase = io::strstr(cmdline, "vc_mem.mem_base=");
+  const char *vcBase = strstr(cmdline, "vc_mem.mem_base=");
   if (vcBase) {
     // The bootloader inserts two space between the boot data and the
     // user-supplied commandline
-    const char *userCmdLine = io::strstr(cmdline, "  ");
+    const char *userCmdLine = strstr(cmdline, "  ");
     if (userCmdLine) {
       info->cmdline = userCmdLine + 2;
     } else {
@@ -77,9 +77,9 @@ extern "C" void _systemSetup(BootInfo *info) {
 
     // Figure out where our memory ends - this is where the videocore memory
     // starts. At leas I thinks so. Could not find any docs.
-    vcBase += io::strlen("vc_mem.mem_base="); // name
+    vcBase += strlen("vc_mem.mem_base="); // name
     const char *ptr = vcBase;
-    uint64_t heapEnd = io::strtoul(vcBase, &ptr, 16);
+    uint64_t heapEnd = strtoul(vcBase, &ptr, 16);
     if (ptr != vcBase && *ptr == ' ') {
       info->heapEnd = heapEnd;
     }

--- a/io/BUILD.go
+++ b/io/BUILD.go
@@ -9,6 +9,5 @@ var Lib = lib.Library{
 	Srcs: ins(
 		"printf.cc",
 		"io.cc",
-		"string.cc",
 	),
 }

--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -3,5 +3,4 @@ add_library(
   io STATIC
   printf.cc
   io.cc
-  string.cc
 )

--- a/io/printf.cc
+++ b/io/printf.cc
@@ -23,8 +23,8 @@
 
 #include "libsupcxx/io/printf.hh"
 #include "libsupcxx/io/io.hh"
-#include "libsupcxx/io/string.hh"
 
+#include <cstring>
 #include <stdarg.h>
 
 namespace {

--- a/libsupcxx/include/cstring
+++ b/libsupcxx/include/cstring
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright (C) 2018-2019 Daedalean AG
+// Copyright (C) 2021 Daedalean AG
 //
 // This library is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
@@ -25,12 +25,8 @@
 
 #include <cstddef>
 
-namespace io {
-
 extern "C" size_t strlen(const char *str);
 extern "C" char *strncpy(char *dest, const char *src, size_t num);
 extern "C" int strncmp(const char *s1, const char *s2, size_t n);
 const char *strstr(const char *haystack, const char *needle);
 unsigned long strtoul(const char *nptr, const char **endptr, int base);
-
-} // namespace io

--- a/libsupcxx/src/BUILD.go
+++ b/libsupcxx/src/BUILD.go
@@ -49,5 +49,7 @@ var Lib = lib.Library{
 		"eh_throw.cc",
 		"eh_catch.cc",
 		"eh_call.cc",
+
+		"cstring.cc",
 	),
 }

--- a/libsupcxx/src/CMakeLists.txt
+++ b/libsupcxx/src/CMakeLists.txt
@@ -48,4 +48,6 @@ add_library(
   eh_throw.cc
   eh_catch.cc
   eh_call.cc
+
+  cstring.cc
   )

--- a/libsupcxx/src/cstring.cc
+++ b/libsupcxx/src/cstring.cc
@@ -41,6 +41,8 @@
 
 #include "limits.h"
 
+
+namespace {
 inline bool isalpha(char c) {
   return (c >= 65 && c < 90) || (c >= 97 && c < 122);
 }
@@ -59,6 +61,7 @@ inline bool isupper(char c) {
 
 inline bool isascii(char c) {
   return ((c) & ~0x7F) == 0;
+}
 }
 
 int strncmp(const char *s1, const char *s2, size_t n) {

--- a/libsupcxx/src/cstring.cc
+++ b/libsupcxx/src/cstring.cc
@@ -37,10 +37,10 @@
 // SUCH DAMAGE.
 //------------------------------------------------------------------------------
 
-#include "libsupcxx/io/string.hh"
+#include <cstring>
+
 #include "limits.h"
 
-namespace {
 inline bool isalpha(char c) {
   return (c >= 65 && c < 90) || (c >= 97 && c < 122);
 }
@@ -60,9 +60,7 @@ inline bool isupper(char c) {
 inline bool isascii(char c) {
   return ((c) & ~0x7F) == 0;
 }
-}
 
-namespace io {
 int strncmp(const char *s1, const char *s2, size_t n) {
   if (n == 0) {
     return 0;
@@ -165,5 +163,4 @@ unsigned long strtoul(const char *nptr, const char **endptr, int base) {
     *endptr = any ? s - 1 : nptr;
   }
   return acc;
-}
 }


### PR DESCRIPTION
This closes #6, now boot/ only depends on the stdlib in libsupcxx/ and not on io/ .