### PR TITLE
Support multiple memory regions, all targets still only use one

### DIFF
--- a/boot/bootinfo.hh
+++ b/boot/bootinfo.hh
@@ -23,8 +23,17 @@
 
 #include <stdint.h>
 
+enum class MemoryType : uint32_t { INACCESSIBLE, RAM, DEVICE };
+
+struct MemoryRegion {
+  uint64_t start;
+  uint64_t end;
+  uint64_t offset;  //!< Offset to be used in the device context (ie. when assigning BARs)
+  MemoryType type;
+};
+
 struct [[gnu::packed]] BootInfo {
   const char *cmdline;
-  uint64_t heapStart;
-  uint64_t heapEnd;
+  MemoryRegion memoryMap[32];
+  uint32_t numMemoryRegions;
 };

--- a/boot/raspi3/kernel.ld
+++ b/boot/raspi3/kernel.ld
@@ -50,12 +50,12 @@ SECTIONS
     /* These need to be 8-byte aligned */
     . = ALIGN(8);
     __initArrayBegin = .;
-    *(.init_array)
+    *(SORT(.init_array*))
     __initArrayEnd = .;
 
     . = ALIGN(8);
     __finiArrayBegin = .;
-    *(.fini_array)
+    *(SORT(.fini_array*))
     __finiArrayEnd = .;
 
     *(.rodata*)

--- a/boot/x86_64/setup.cc
+++ b/boot/x86_64/setup.cc
@@ -52,8 +52,7 @@ extern "C" void _systemSetup(BootInfo *info) {
     "or $0x00000600, %eax\n\t"  // enable SSE and SSE exceptions
     "mov %eax, %cr4\n\t");      // the OSFXSR and OSXMMEXCPT bits
 
-  if (info->numMemoryRegions == 0 ||
-      info->memoryMap[0].type != MemoryType::RAM) {
+  if (info->numMemoryRegions == 0 || info->memoryMap[0].type != MemoryType::RAM) {
     return;
   }
 
@@ -108,7 +107,7 @@ extern "C" void _systemSetup(BootInfo *info) {
       uint64_t pdptEntry = pdpt[pdptIndex];
       pdptEntry &= ADDR_MASK;
       pdt = (uint64_t *)pdptEntry;
-      // We need a pdt for this page
+    // We need a pdt for this page
     } else {
       pdt = pdt1;
       uint64_t pdptEntry = (uint64_t)pdt;

--- a/libruncxx/memory.cc
+++ b/libruncxx/memory.cc
@@ -106,15 +106,6 @@ namespace {
       continue;
     }
 
-    // If the start address is above 4G and we're 32bits then it's useless
-    if (sizeof(int *) == 4 && start >= 0xffffffff) {
-      continue;
-    }
-
-    // It may start before 4G but end after
-    if (sizeof(int *) == 4 && end > 0xffffffff) {
-      end = 0xffffffff;
-    }
     uint64_t size = end - start;
 
     // Check if this RAM segment contains the kernel


### PR DESCRIPTION
The platform-independent code now supports discontinuous memory regions, but all of the platforms only generate one. 
All platforms have been tested. 
I had to fix a bug in raspi3's linker script that prevented constructor registration. 
clang-format restyled some of the existing code in the files I changed.