### PR TITLE
Remove reconfigureHeap + move BootInfo definition to memory.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ therefore, can be run using `qemu`. To install `qemu` on Ubuntu, type:
 
 To run the tests, type:
 
-    qemu-system-i386 -kernel tests/test-07-throw-clean-up-rethrow.elf
+    qemu-system-i386 -serial stdio -kernel tests/test-07-throw-clean-up-rethrow.elf
 
 The binaries are built in debug mode by default and may be debugged using GDB.
 Run `qemu` in one terminal window:
 
-    qemu-system-i386 -S -s -kernel tests/test-07-throw-clean-up-rethrow.elf
+    qemu-system-i386 -serial stdio -S -s -kernel tests/test-07-throw-clean-up-rethrow.elf
 
 The `-s` parameter is a shorthand for `-gdb tcp::1234` and will start a GDB
 server at `localhost:1234`, `-S` tells `qemu` to not start the virtual CPU,

--- a/boot/linux-x86_64/setup.cc
+++ b/boot/linux-x86_64/setup.cc
@@ -36,7 +36,7 @@ static const char *MMAP_ERR_MSG = "libsupcxx setup error\n";
 
 extern "C" uint64_t _syscall(uint64_t syscall, ...);
 
-BootInfo bootInfo;
+extern BootInfo bootInfo;
 
 // Similar to standard getenv, but takes envp as argument
 extern "C" const char *_getenv(const char **envp, const char *name) {

--- a/boot/raspi3/setup.cc
+++ b/boot/raspi3/setup.cc
@@ -33,7 +33,7 @@ extern uint32_t __initArrayEnd;
 extern uint32_t __finiArrayBegin;
 extern uint32_t __finiArrayEnd;
 
-BootInfo bootInfo;
+extern BootInfo bootInfo;
 
 // Page tables - we will only address the first 1GB using 2MB pages
 uint64_t tableL1[512] [[gnu::aligned(4096)]];

--- a/boot/x86_64/multiboot.cc
+++ b/boot/x86_64/multiboot.cc
@@ -41,7 +41,7 @@ struct MbInfo {
   uint32_t mmapAddr;
 };
 
-BootInfo bootInfo;
+extern BootInfo bootInfo;
 
 // This variable does not exist, but it's address is known to the linker. See
 // the linker script for details.

--- a/io/memory.hh
+++ b/io/memory.hh
@@ -31,5 +31,4 @@ struct Region {
 };
 extern "C" void *malloc(size_t size);
 extern "C" void free(void *ptr);
-extern "C" void reconfigureHeap(Region regions[], unsigned int numRegions);
 } // namespace io

--- a/libruncxx/memory.cc
+++ b/libruncxx/memory.cc
@@ -89,26 +89,7 @@ extern "C" void free(void *ptr) {
   chunk->size &= ~MEMCHUNK_USED;
 }
 
-extern "C" void reconfigureHeap(io::Region regions[], unsigned int numRegions) {
-  if (numRegions == 0) {
-    head = 0;
-    return;
-  }
-
-  for (uint32_t i = 0; i < numRegions; ++i) {
-    MemChunk *chunk = (MemChunk *)regions[i].address;
-    chunk->size = regions[i].size;
-    if (i + 1 == numRegions) {
-      chunk->next = nullptr;
-    } else {
-      chunk->next = (MemChunk *)regions[i + 1].address;
-    }
-  }
-
-  head = (MemChunk *)regions[0].address;
-}
-
-extern BootInfo bootInfo;
+BootInfo bootInfo = {"", {}, 0};
 
 namespace {
 [[gnu::constructor]] void setUpHeap() {


### PR DESCRIPTION
reconfigureHeap was only introduced for the original Vyper, but is no longer needed